### PR TITLE
Enable ifx support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,27 +27,72 @@ include_directories("${CMAKE_BINARY_DIR}/src/RKH_frame")
 # Make sure color ouput is used by the build system for more readable error messages and warnings
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Set allowed config types
+set(ALLOWED_CONFIGS Debug Sanitize Release RelWithDebInfo)
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING
+        "Choose the type of build" FORCE
+    )
+endif ()
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${ALLOWED_CONFIGS})
+message(STATUS "Selected CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+
+# Set compiler flags for compilers and build types
+add_library(project_options INTERFACE)
+
 # Set compiler flags that should always be on
-add_compile_options(-Wall -fopenmp -cpp)
-add_compile_options(-fdefault-integer-8) # Use 64-bit integers
-add_link_options(-fopenmp)
+target_compile_options(project_options INTERFACE
+    # GNU Fortran
+    $<$<Fortran_COMPILER_ID:GNU>:
+        -Wall
+        -cpp
+        -fdefault-integer-8>
+
+    # Intel ifx
+    $<$<Fortran_COMPILER_ID:IntelLLVM>:
+        -warn all
+        -fpp
+        -i8>
+)
 
 # Set flags for compilation choices
-if (CMAKE_BUILD_TYPE STREQUAL "debug")
-    add_compile_options(-O0 -fcheck=all -g -fbacktrace)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(project_options INTERFACE
+        $<$<Fortran_COMPILER_ID:GNU>: -O0 -fcheck=all -g -fbacktrace>
+        $<$<Fortran_COMPILER_ID:IntelLLVM>: -O0 -g -check all -traceback>
+    )
+elseif(CMAKE_BUILD_TYPE STREQUAL "Sanitize")
+    target_compile_options(project_options INTERFACE
+        $<$<Fortran_COMPILER_ID:GNU>: -O0 -g -fsanitize=address -fno-omit-frame-pointer -fbacktrace>
+        $<$<Fortran_COMPILER_ID:IntelLLVM>: -O0 -g -fsanitize=address -fno-omit-frame-pointer -traceback>
+    )
+    target_link_options(project_options INTERFACE
+        -fsanitize=address
+    )
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_options(project_options INTERFACE
+        $<$<Fortran_COMPILER_ID:GNU>: -O3 -march=native -mtune=native>
+        $<$<Fortran_COMPILER_ID:IntelLLVM>: -O3 -xHost>
+    )
+elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    target_compile_options(project_options INTERFACE
+        $<$<Fortran_COMPILER_ID:GNU>: -O3 -march=native -mtune=native -g -fbacktrace>
+        $<$<Fortran_COMPILER_ID:IntelLLVM>: -O3 -xHost -g -traceback>
+    )
 else()
-    add_compile_options(-O3 -march=native -mtune=native)
+    message(FATAL_ERROR
+        "Unknown CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}\n"
+        "CMAKE_BUILD_TYPE should be one of: ${ALLOWED_CONFIGS}"
+    )
 endif()
+
+# Make sure OpenMP flags are set
+find_package(OpenMP REQUIRED)
+target_link_libraries(project_options INTERFACE OpenMP::OpenMP_Fortran)
 
 option(USE_DEBUG_PARDISO "Enable debugging mode of PARDISO" OFF)
 if (USE_DEBUG_PARDISO)
     add_compile_definitions(DEBUG_PARDISO)
-endif()
-
-# Enable address sanitizer for gcc
-if (CMAKE_USE_ASAN)
-        add_compile_options(-fsanitize=address)
-        add_link_options(-fsanitize=address)
 endif()
 
 # Tell MKL to use 32-bit integer interface
@@ -68,9 +113,12 @@ find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
 # Check if FEAST is available
-find_library(feast NAMES feast PATHS "$ENV{FEASTROOT}/lib/x64/")
-if (feast)
-    add_compile_definitions(WITH_FEAST)
+option(USE_FEAST "Enable FEAST" OFF)
+if (USE_FEAST)
+    find_library(feast NAMES feast PATHS "$ENV{FEASTROOT}/lib/x64/")
+    if (feast)
+        add_compile_definitions(WITH_FEAST)
+    endif()
 endif()
 
 # Add subdirectories
@@ -91,12 +139,12 @@ add_executable(time_prop src/apps/main_time_prop.f90)
 add_executable(RKH src/apps/main_RKH.f90)
 
 # Link libraries to executable
-target_link_libraries(basis_setup mat_els tools)
-target_link_libraries(quasi quasienergies tools)
-target_link_libraries(diag diagonalization tools)
-target_link_libraries(feval function_eval tools)
-target_link_libraries(time_prop time_dep quasienergies tools)
-target_link_libraries(RKH RKH_frame tools)
+target_link_libraries(basis_setup PRIVATE mat_els tools project_options)
+target_link_libraries(quasi PRIVATE quasienergies tools project_options)
+target_link_libraries(diag PRIVATE diagonalization tools project_options)
+target_link_libraries(feval PRIVATE function_eval tools project_options)
+target_link_libraries(time_prop PRIVATE time_dep quasienergies tools project_options)
+target_link_libraries(RKH PRIVATE RKH_frame tools project_options)
 
 # Install executable in binary direcetory
 set(executables basis_setup quasi diag feval time_prop RKH)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # b-spline-two-e
 A program that computes matrix elements for one- and two-electron atoms in the non-relativistic and dipole approximations (including the singlet approximation).
-The radial part of the wavefunctions are represented using B-splines.
+The radial part of the wavefunctions are represented using B-splines. The program utilizes OpenMP for parallel processing.
 
 ## Requirements
 The currently supported compilers are
-- gfortran 10+
+- ```gfortran``` 10+, ```ifx```
   
 The program needs the following external libraries
 - The GNU Scientific Library (GSL) https://www.gnu.org/software/gsl/
@@ -41,23 +41,34 @@ Once you have cloned the repository, do the following:
 
 A shell script for building the program and its prerequisites on AWS-Linux 2023 can be found in ```utils/install_bs2e_aws_linux_2023.sh```
 
-## Turn on debug build
-In the build directory run cmake with the debug flag set
-```
-cmake -DCMAKE_BUILD_TYPE=debug ..
-```
-This adds runtime checks, debug symbols, and sets the optimization level to -O0.
-If you additionaly want to enable the address sanitizer add
-```
--DCMAKE_USE_ASAN=1
-```
-when you run CMake.
+## Configure the build
+These are options that can be set when running CMake in order to configure your build.
 
+### Setting the Fortran compiler
+A specific compiler and version can be specified using ```-DCMAKE_Fortran_COMPILER=compiler```
+Currently, only ```gfortran``` and ```ifx``` are supported.
+
+### Setting the build type
+There are currently four build types available, and they can be set via the ```-DCMAKE_BUILD_TYPE=Type``` flag.
+The current options are:
+- ```Debug``` Optimization level: -O0. Runtime checks, debug symbols, and backtrace enabled.
+- ```Sanitize``` Optimization level: -O0. Address sanitizer, debug symbols, and backtrace enabled. 
+- ```Release``` Optimization level: -O3. For ```gfortran``` also enables ```-march=native -mtune=native```, and for ```ifx``` enables ```-xHost```.
+- ```RelWithDebInfo``` Same as ```Release```, but with debug symbols and backtrace enabled.
+
+```Release``` is the default build type, and is used if ```-DCMAKE_BUILD_TYPE``` is not specified.
+
+### Debug PARDISO
 To enable more checks for PARDISO and printing of information add:
 ```
 -DUSE_DEBUG_PARDISO=ON
 ```
-when you run CMake.
+
+### Build with FEAST
+If you want to enable FEAST set
+```
+-DUSE_FEAST=ON
+```
 
 ## Currently available programs
   - ```basis_setup``` For setting up the basis and computing matrix elements.
@@ -76,3 +87,5 @@ To run e.g. ```basis_setup```, run
 Note that the output directory needs to be specfied in the input file, and it should exist before running the program (otherwise you will get an error).
 The output of the program will be stored in a numbered folder created inside the output directory specified in the input file 
 (except in the case of ```feval``` where a ```function_eval``` directory is created in the directory where the vectors are stored).
+
+The number of threads used in OpenMP sections of the program can be controlled by setting the ```OMP_NUM_THREADS``` environment variable.

--- a/src/RKH_frame/CMakeLists.txt
+++ b/src/RKH_frame/CMakeLists.txt
@@ -8,5 +8,6 @@ add_library(RKH_frame ${RKH_frame_files})
 target_link_libraries(RKH_frame PRIVATE fortran_stdlib::fortran_stdlib)
 target_link_libraries(RKH_frame PRIVATE tools)
 target_link_libraries(RKH_frame PRIVATE function_eval)
+target_link_libraries(RKH_frame PRIVATE project_options)
 
 install(TARGETS RKH_frame DESTINATION lib)

--- a/src/RKH_frame/adiabatic_potentials.f90
+++ b/src/RKH_frame/adiabatic_potentials.f90
@@ -173,7 +173,7 @@ contains
             do j = 1,n_sym
                 write(unit, '(a,es25.17e3)', advance = 'no') ' ', U_r_vals(j,i)
             end do
-            write(unit,*) ''
+            write(unit,'()')
         end do
         close(unit)
 

--- a/src/diagonalization/CMakeLists.txt
+++ b/src/diagonalization/CMakeLists.txt
@@ -5,5 +5,6 @@ set(diagonalization_files
 add_library(diagonalization ${diagonalization_files})
 
 target_link_libraries(diagonalization PRIVATE tools)
+target_link_libraries(diagonalization PRIVATE project_options)
 
 install(TARGETS diagonalization DESTINATION lib)

--- a/src/function_eval/CMakeLists.txt
+++ b/src/function_eval/CMakeLists.txt
@@ -7,5 +7,6 @@ add_library(function_eval ${function_eval_files})
 target_link_libraries(function_eval PRIVATE fortran_stdlib::fortran_stdlib)
 target_link_libraries(function_eval PRIVATE tools)
 target_link_libraries(function_eval PRIVATE mat_els)
+target_link_libraries(function_eval PRIVATE project_options)
 
 install(TARGETS function_eval DESTINATION lib)

--- a/src/function_eval/function_eval.f90
+++ b/src/function_eval/function_eval.f90
@@ -116,7 +116,7 @@ contains
 
         ptr = 1
         do i = 1,bas%n_sym
-            write(unit,*)''
+            write(unit,'()')
             write(unit,'(I4,I4)') bas%syms(i)%l,bas%syms(i)%m
 
             coeffs = (0.0_dp,0.0_dp)
@@ -143,8 +143,7 @@ contains
                     write(unit,'(es24.17e3)', advance='no') aimag(val)
                 end if
 
-                write(unit,'(a)', advance='no') 'j) '
-                write(unit,*)''
+                write(unit,'(a)') 'j) '
             end do
 
         end do
@@ -173,7 +172,7 @@ contains
         end do
 
         do i = 1,bas%n_sym
-            write(unit,*)''
+            write(unit,'()')
             if (lm_basis) then
                 write(unit,'(I4,I4)') bas%syms(i)%l,bas%syms(i)%m
             else
@@ -200,8 +199,7 @@ contains
                     write(unit,'(es24.17e3)', advance='no') aimag(val)
                 end if
 
-                write(unit,'(a)', advance='no') 'j) '
-                write(unit,*)''
+                write(unit,'(a)') 'j) '
             end do
 
         end do

--- a/src/mat_els/CMakeLists.txt
+++ b/src/mat_els/CMakeLists.txt
@@ -8,6 +8,7 @@ set(mat_els_files
 
 add_library(mat_els ${mat_els_files})
 
-target_link_libraries(mat_els tools)
+target_link_libraries(mat_els PRIVATE tools)
+target_link_libraries(mat_els PRIVATE project_options)
 
 install(TARGETS mat_els DESTINATION lib)

--- a/src/quasienergies/CMakeLists.txt
+++ b/src/quasienergies/CMakeLists.txt
@@ -11,5 +11,6 @@ add_library(quasienergies ${quasienergies_files})
 target_link_libraries(quasienergies PRIVATE fortran_stdlib::fortran_stdlib)
 target_link_libraries(quasienergies PRIVATE tools)
 target_link_libraries(quasienergies PRIVATE diagonalization)
+target_link_libraries(quasienergies PRIVATE project_options)
 
 install(TARGETS quasienergies DESTINATION lib)

--- a/src/quasienergies/essential_states.f90
+++ b/src/quasienergies/essential_states.f90
@@ -249,9 +249,9 @@ contains
 
                 write(stdout,'(a)', advance='no') ') '
             end do
-            write(stdout,*)''
+            write(stdout,'()')
         end do
-        write(stdout,*)''
+        write(stdout,'()')
 
         ! Workspace query for eigenvalues
         allocate(rwork(2*n_ess))

--- a/src/quasienergies/quasi_calcs.f90
+++ b/src/quasienergies/quasi_calcs.f90
@@ -382,9 +382,9 @@ contains
             do kk = 1,n_quasi
                 write(stdout,'(es24.17e3,a)',advance='no') abs(ess_projs(kk,j,i)), ' '
             end do
-            write(stdout,*)''
+            write(stdout,'()')
         end do
-        write(stdout,*)''
+        write(stdout,'()')
     end subroutine compute_projections
 
     subroutine cleanup_solvers()
@@ -521,7 +521,7 @@ contains
 
                 write(unit,'(a)', advance='no') 'j) '
             end do
-            write(unit,*)''
+            write(unit,'()')
         end do
 
         close(unit)
@@ -543,9 +543,9 @@ contains
                     do kk = 1,n_quasi
                         write(unit,'(es24.17e3,a)',advance = 'no') abs(ess_projs(kk,j,i)), ' '
                     end do
-                    write(unit,*)''
+                    write(unit,'()')
                 end do
-                write(unit,*)''
+                write(unit,'()')
             end do
 
             close(unit)
@@ -584,9 +584,9 @@ contains
 
                         write(unit,'(a)', advance='no') 'j) '
                     end do
-                    write(unit,*)''
+                    write(unit,'()')
                 end do
-                write(unit,*)''
+                write(unit,'()')
             end do
 
             close(unit)
@@ -897,12 +897,12 @@ contains
         vecs(:,:,i) = vecs_i
         eigs(:,i) = eigs_i
 
-        write(stdout,*) ''
+        write(stdout,'()')
         write(stdout,*) 'Reordered eigenvalues with projections:'
         do j=1,n_quasi
             write(stdout,*) eigs(j,i), projs(j)
         end do
-        write(stdout,*) ''
+        write(stdout,'()')
     end subroutine reorder_proj
 
     subroutine start_timer()

--- a/src/time_dep/CMakeLists.txt
+++ b/src/time_dep/CMakeLists.txt
@@ -9,5 +9,6 @@ add_library(time_dep ${time_dep_files})
 target_link_libraries(time_dep PRIVATE fortran_stdlib::fortran_stdlib)
 target_link_libraries(time_dep PRIVATE tools)
 target_link_libraries(time_dep PRIVATE quasienergies)
+target_link_libraries(time_dep PRIVATE project_options)
 
 install(TARGETS time_dep DESTINATION lib)

--- a/src/time_dep/time_propagation.f90
+++ b/src/time_dep/time_propagation.f90
@@ -113,6 +113,7 @@ contains
         call save_vec(1)
         do i = 1,N_t-1
             write(stdout,'(a,a,i0,a,i0)',advance='no') achar(13),'Timestep: ', i, '/', N_t
+            flush(unit=stdout)
             ! write(stdout,*) abs(ess_states(1)%projection(psi,S%blocks(ess_states(1)%block),full))**2
             call CN_step(t(i),psi,psi_new,A_t(i,:),E_t(i,:))
             call swap(psi,psi_new)
@@ -188,7 +189,7 @@ contains
             do j = 1,n_ess
                 write(unit,'(es25.17e3)', advance='no') abs(projs(i,j))**2
             end do
-            write(unit,*)''
+            write(unit,'()')
         end do
 
         close(unit)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(tools PRIVATE fortran_stdlib::fortran_stdlib)
 target_link_libraries(tools PRIVATE MKL::MKL)
 target_link_libraries(tools PRIVATE GSL::gsl)
 target_link_libraries(tools PRIVATE ARPACK::ARPACK)
+target_link_libraries(tools PRIVATE project_options)
 
 if (feast)
     target_link_libraries(tools PRIVATE ${feast})

--- a/src/tools/dir_tools.f90
+++ b/src/tools/dir_tools.f90
@@ -1,4 +1,5 @@
 module dir_tools
+    use stdlib_system, only: is_directory
     implicit none
 
 contains
@@ -6,7 +7,7 @@ contains
         character(len=:), allocatable, intent(in) :: dir
         logical :: res
 
-        inquire(file=dir,exist=res)
+        res = is_directory(dir)
     end function is_dir
 
     subroutine mkdir(dir)

--- a/src/tools/sparse_array_tools.f90
+++ b/src/tools/sparse_array_tools.f90
@@ -53,7 +53,6 @@ module sparse_array_tools
         type(ptr_type) :: entry
         type(open_hashmap_type) :: map
         real(dp), allocatable :: data(:)
-        class(*), allocatable :: ptr
         integer(int8), allocatable :: indices(:)
     contains
         procedure :: init => init_Nd_DOK
@@ -513,12 +512,12 @@ contains
         real(dp), intent(in) :: val(:)
 
         logical(int32) :: exists
+        class(*), allocatable :: temp
 
         this%indices = transfer(indices,[0_int8])
 
         call this%map%key_test(this%indices,exists)
 
-        associate (temp => this%ptr)
         if (exists) then
             call this%map%get_other_data(this%indices,temp)
             select type (temp)
@@ -532,8 +531,6 @@ contains
             call this%map%map_entry(this%indices,this%entry)
             this%entry%ptr = this%entry%ptr + this%N_val
         end if
-        end associate
-
     end subroutine set_val_Nd_DOK
 
     subroutine get_val_Nd_DOK(this,indices,values)


### PR DESCRIPTION
Enable support for building with ifx. The CMake files have been updated to deal with both gfortran and ifx. Some minor changes have been made to the code to get consistent behavior with both compilers. 

Closes #14.